### PR TITLE
Tuning parameters 

### DIFF
--- a/tap_assembled/streams/activities.py
+++ b/tap_assembled/streams/activities.py
@@ -32,7 +32,7 @@ class ActivitiesStream(BaseStream):
             date = get_config_start_date(self.config)
 
         interval_sliding = timedelta(days=1)
-        interval = timedelta(days=7) # TODO: check whether 15 days are large enough
+        interval = timedelta(days=7)
 
         # sync incrementally - by day
         while date < datetime.now(pytz.utc):

--- a/tap_assembled/streams/activities.py
+++ b/tap_assembled/streams/activities.py
@@ -12,7 +12,7 @@ LOGGER = singer.get_logger()
 
 class ActivitiesStream(BaseStream):
     NAME = "ActivitiesStream"
-    KEY_PROPERTIES = ["id", "agent_id"]
+    KEY_PROPERTIES = ["id", "agent_id", "type_id"]
     API_METHOD = "GET"
     TABLE = "activities"
 
@@ -32,7 +32,7 @@ class ActivitiesStream(BaseStream):
             date = get_config_start_date(self.config)
 
         interval_sliding = timedelta(days=1)
-        interval = timedelta(days=15) # TODO: check whether 15 days are large enough
+        interval = timedelta(days=7) # TODO: check whether 15 days are large enough
 
         # sync incrementally - by day
         while date < datetime.now(pytz.utc):


### PR DESCRIPTION
A couple of changes: 

1. Reduced the sliding windows size for activities, from 15 days to 7 days to reduce data exchange overheads.  Also, no impact on data correctness.
2. Added additional key_property (type_id) for activities to avoid potential overwrites. 