### PR TITLE
FUJ-2056: add support for the adherence report

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="tap-assembled",
-    version="0.1.1",
+    version="0.1.2",
     description="Singer.io tap for extracting data from the Assembled API",
     author="Pathlight",
     url="http://pathlight.com",

--- a/tap_assembled/schemas/adherence.json
+++ b/tap_assembled/schemas/adherence.json
@@ -1,0 +1,30 @@
+{
+    "type": "object",
+    "additionalProperties": true,
+    "properties": {
+        "name": {
+            "type": ["null", "string"]
+        },
+        "value": {
+            "type": ["null", "string"]
+        },
+        "agent_id": {
+            "type": ["null", "string"]
+        },
+        "start_time": {
+            "type": "string",
+            "format": "date-time"
+        },
+        "end_time": {
+            "type": "string",
+            "format": "date-time"
+        },
+        "type": {
+            "type": ["null", "string"]
+        },
+        "channel": {
+            "type": ["null", "string"]
+        }
+    }
+}
+

--- a/tap_assembled/streams/__init__.py
+++ b/tap_assembled/streams/__init__.py
@@ -2,12 +2,14 @@ from tap_assembled.streams.agents import AgentsStream
 from tap_assembled.streams.agent_states import AgentStatesStream
 from tap_assembled.streams.activities import ActivitiesStream
 from tap_assembled.streams.activity_types import ActivityTypesStream
+from tap_assembled.streams.adherence import AdherenceStream
 
 AVAILABLE_STREAMS = [
     AgentsStream,
     ActivityTypesStream,
     ActivitiesStream,
     AgentStatesStream,
+    AdherenceStream
 ]
 
 __all__ = [s.NAME for s in AVAILABLE_STREAMS]

--- a/tap_assembled/streams/activities.py
+++ b/tap_assembled/streams/activities.py
@@ -35,7 +35,7 @@ class ActivitiesStream(BaseStream):
         interval = timedelta(days=7)
 
         # sync incrementally - by day
-        while date < datetime.now(pytz.utc):
+        while pytz.utc.localize(date) < datetime.now(pytz.utc):
             self.sync_for_period(date, interval)
 
             # keep bookmark updated

--- a/tap_assembled/streams/adherence.py
+++ b/tap_assembled/streams/adherence.py
@@ -33,7 +33,6 @@ class AdherenceStream(BaseStream):
 		LOGGER.info(f"tap-assembled: retrieving report id {report_id}")
 		result = self.client.make_request(url, "GET", params=params)
 		status = result['status']
-		print(status)
 		attempts_count = 0
 
 		while ("in_progress" == status) & (attempts_count < self.MAX_REPORT_ATTEMPTS): 
@@ -144,10 +143,9 @@ class AdherenceStream(BaseStream):
 			date = get_config_start_date(self.config)
 
 		interval_sliding = timedelta(days=1)
-		interval = timedelta(days=7)
+		interval = timedelta(days=1)
 
 		# sync incrementally - by day
-		#TODO:  don't sync for end dates in the future
 		while pytz.utc.localize(date) < datetime.now(pytz.utc):
 			self.sync_for_period(date, interval)
 

--- a/tap_assembled/streams/adherence.py
+++ b/tap_assembled/streams/adherence.py
@@ -1,0 +1,129 @@
+from tap_assembled.streams.base import BaseStream
+
+import singer
+import pytz
+import time
+
+from datetime import timedelta, datetime
+from tap_assembled.config import get_config_start_date
+from tap_assembled.state import incorporate, save_state, get_last_record_value_for_table
+
+LOGGER = singer.get_logger()
+
+
+class AdherenceStream(BaseStream):
+	NAME = "AdherenceStream"
+	TABLE = "adherence"
+	INTERVAL = "24h" # assumes a time range of > 1 day
+	PHONE = "phone"
+	EMAIL = "email"
+	CHANNEL_TYPES = [PHONE, EMAIL]
+	
+	REPORT_GENERATION_PAUSE_IN_SECS = 10
+
+	@property
+	def api_path(self):
+		return "/reports/adherence"
+
+	def get_report(self, result):
+		# retrieve the report id from the results and use it to retrieve the associated metrics
+		if not result or "report_id" not in result:
+			return []
+		
+		report_id = result.get("report_id")
+		params = {"limit": 500} # default value; TODO: consider increasing or handle pagination
+		url = f"{self.client.base_url}/reports/{report_id}"
+		
+		time.sleep(self.REPORT_GENERATION_PAUSE_IN_SECS)
+		LOGGER.info(f"tap-assembled: retrieving report id {report_id}")
+		result = self.client.make_request(url, "GET", params=params)
+		status = result['status']
+
+		while ("in_progress" == status): 
+			# TODO:  eventually need to fail this process
+			time.sleep(self.REPORT_GENERATION_PAUSE_IN_SECS)
+			LOGGER.info(f"tap-assembled: re-trying report id {report_id}")
+			result = self.client.make_request(url, "GET", params=params)
+			status = result['status']
+			
+		#LOGGER.info("report contents:")
+		#LOGGER.info(result['status'])
+		LOGGER.info(result['total_metric_count'])
+		return result
+	
+	def get_stream_data(self, result, channel):
+		if not result or "metrics" not in result:
+			return []
+
+		metrics = []
+		for metric in result["metrics"]:
+
+			# flatten record
+			metric["agent_id"] = metric["attributes"]["agent_id"]
+			metric["type"] = metric["attributes"]["type"]
+			
+			# conversion from ts to utc, as singer does not support its transformation
+			metric["start_time"] = self.convert_timestamp_utc(metric["attributes"]["start_time"])
+			metric["end_time"] = self.convert_timestamp_utc(metric["attributes"]["end_time"])
+			
+			# add additional fields
+			metric["channel"] = channel
+
+			# data transformation by singer
+			LOGGER.info(metric) # debug
+			metrics.append(self.transform_record(metric))
+
+		return metrics
+
+	def sync_for_period_and_channel(self, date, interval, channel):
+		table = self.TABLE
+
+		date_from = round(self.convert_utc_timestamp(date))
+		date_to = round(self.convert_utc_timestamp(date + interval))
+
+		LOGGER.info(
+			f"tap-assembled: syncing {table} table for {channel} from {date.isoformat()} to {(date+interval).isoformat()}"
+		)
+		
+		body = {"start_time": date_from, "end_time": date_to, "interval": self.INTERVAL, "channel": channel}
+		url = f"{self.client.base_url}{self.api_path}"
+
+		result = self.client.make_request(url, "POST", body=body)
+		report = self.get_report(result) 
+		data = self.get_stream_data(report, channel)
+
+		if len(data) > 0:
+			with singer.metrics.record_counter(endpoint=table) as counter:
+				for obj in data:
+					singer.write_records(table, [obj])
+				counter.increment(len(data))
+
+
+	def sync_for_period(self, date, interval):
+		for channel in self.CHANNEL_TYPES:
+			self.sync_for_period_and_channel(date, interval, channel)
+			
+	# activity sync over time period - incremental
+	def sync_data(self):
+		table = self.TABLE
+
+		LOGGER.info(f"tap-assembled: syncing data for entity {table}")
+
+		date = get_last_record_value_for_table(self.state, table)
+
+		if not date:
+			date = get_config_start_date(self.config)
+
+		interval_sliding = timedelta(days=1)
+		interval = timedelta(days=7)
+
+		# sync incrementally - by day
+		while pytz.utc.localize(date) < datetime.now(pytz.utc):
+			self.sync_for_period(date, interval)
+
+			# keep bookmark updated
+			self.state = incorporate(
+				self.state, self.TABLE, "last_record", date.isoformat()
+			)
+			save_state(self.state)
+			date = date + interval_sliding


### PR DESCRIPTION
API is documented at https://docs.assembled.com/#reports.

Typical row of data returned by this new stream:

`{"type": "RECORD", "stream": "adherence", "record": {"name": "utilization", "value": "0.9545454545454546", "agent_id": "ff08d561-fdd1-48c7-af4d-f3b364d1a2e0", "type": "full_interval", "start_time": "2022-06-03T00:00:00.000000Z", "end_time": "2022-06-04T00:00:00.000000Z", "channel": "email"}}`

Note some of the following logic:

- The api works by first requesting a report for a given timeframe, then polling until that report is ready.  
- The api specifies both a timeframe and an interval to aggregate data within that timeframe. After some experimentation, I landed on just pulling a day's worth of data at a time and not using any smaller intervals.
- Handles pagination of the API calls.  I was initially testing using smaller intervals, in which the reports frequently had more than 500 rows. Without smaller intervals and for Maisonette, I doubt we're likely to need pagination, but leaving this code in so that we can handle larger organizations down the line.  (size of a report = # of agents * # of intervals within the period * 8 [because there are 8 metrics])

I'm probably going to proceed with merging this PR so I can start testing deploying the tap, but would appreciate the review anyway - thanks.
