### PR TITLE
FUJ-2056 - bug fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="tap-assembled",
-    version="0.1.3",
+    version="0.1.4",
     description="Singer.io tap for extracting data from the Assembled API",
     author="Pathlight",
     url="http://pathlight.com",

--- a/tap_assembled/streams/adherence.py
+++ b/tap_assembled/streams/adherence.py
@@ -13,6 +13,7 @@ LOGGER = singer.get_logger()
 
 class AdherenceStream(BaseStream):
 	NAME = "AdherenceStream"
+	KEY_PROPERTIES = []
 	TABLE = "adherence"
 	INTERVAL = "24h" # assumes a time range of > 1 day
 	PHONE = "phone"
@@ -131,7 +132,7 @@ class AdherenceStream(BaseStream):
 		for channel in self.CHANNEL_TYPES:
 			self.sync_for_period_and_channel(date, interval, channel)
 			
-	# activity sync over time period - incremental
+	# adherence sync over time period - incremental
 	def sync_data(self):
 		table = self.TABLE
 
@@ -146,7 +147,7 @@ class AdherenceStream(BaseStream):
 		interval = timedelta(days=1)
 
 		# sync incrementally - by day
-		while pytz.utc.localize(date) < datetime.now(pytz.utc):
+		while date < datetime.now(pytz.utc):
 			self.sync_for_period(date, interval)
 
 			# keep bookmark updated


### PR DESCRIPTION
- Fix for `ValueError: Not naive datetime (tzinfo is already set)` error
- Fix for `[tap] 2022-06-05 17:23:54,895 MainThread 140031042406144 /app/target-venv/lib/python3.7/site-packages/target_postgres/db_sync.py:369 (sync_table): INFO Table 'adherence' does not exist. Creating... CREATE TABLE maisonette_assembled.adherence ("agent_id" character varying, "channel" character varying, "end_time" timestamp with time zone, "name" character varying, "start_time" timestamp with time zone, "type" character varying, "value" character varying, PRIMARY KEY ("id", "agent_id", "type_id"))...psycopg2.errors.UndefinedColumn: column "id" named in key does not exist` error