### PR TITLE
FUJ-2056:  do a date only comparison when determining when to run the tap

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="tap-assembled",
-    version="0.1.6",
+    version="0.1.7",
     description="Singer.io tap for extracting data from the Assembled API",
     author="Pathlight",
     url="http://pathlight.com",

--- a/tap_assembled/streams/adherence.py
+++ b/tap_assembled/streams/adherence.py
@@ -147,7 +147,7 @@ class AdherenceStream(BaseStream):
 		interval = timedelta(days=1)
 
 		# sync incrementally - by day, up though yesterday.  Don't pull today's data yet because it is still being generated.
-		while date < (datetime.now(pytz.utc) - interval):
+		while date.date() < (datetime.now(pytz.utc) - interval).date():
 			self.sync_for_period(date, interval)
 
 			# keep bookmark updated


### PR DESCRIPTION
Tested by running locally with two different values in config.json:

`     "start_date": "2022-06-06T00:00:00"`

the run is skipped.

`     "start_date": "2022-06-05T00:00:00"`

the run completes and generates 60 rows.