### PR TITLE
[BUG] Fix Assembled not fetching previous day's data if non-UTC time

### DIFF
--- a/tap_assembled/streams/adherence.py
+++ b/tap_assembled/streams/adherence.py
@@ -143,10 +143,12 @@ class AdherenceStream(BaseStream):
 		interval_sliding = timedelta(days=1)
 		interval = timedelta(days=1)
 
-		# sync incrementally - by day, up though yesterday.  Don't pull today's data yet because it is still being generated.
-		LOGGER.info(f"tap-assembled: comparing {date.date()} to {(datetime.now(pytz.utc) - interval).date()}")
+		# Sync incrementally - by day, up through yesterday. Don't pull today's data yet because it is still being generated.
+		date_format = '%Y-%m-%d %H:%M:%S.%z'
+		end_window = datetime.now(pytz.utc) - interval
+		LOGGER.info(f"tap-assembled: comparing {date.strftime(date_format)} to {end_window.strftime(date_format)}")
 
-		while date.date() < (datetime.now(pytz.utc) - interval).date():
+		while date < (datetime.now(pytz.utc) - interval):
 			LOGGER.info(f"proceeding with sync for {date} and {interval}")
 			self.sync_for_period(date, interval)
 

--- a/tap_assembled/streams/adherence.py
+++ b/tap_assembled/streams/adherence.py
@@ -148,7 +148,7 @@ class AdherenceStream(BaseStream):
 		end_window = datetime.now(pytz.utc) - interval
 		LOGGER.info(f"tap-assembled: comparing {date.strftime(date_format)} to {end_window.strftime(date_format)}")
 
-		while date < (datetime.now(pytz.utc) - interval):
+		while date < end_window:
 			LOGGER.info(f"proceeding with sync for {date} and {interval}")
 			self.sync_for_period(date, interval)
 


### PR DESCRIPTION
This fixes a problem with the Maisonette assembled tap (https://app.pathlight.com/admin/dw/tapconfig/74c3528b-835f-42e0-97ae-5e785c6da9d5/change/)

We set a non-UTC **start_time** in the config.js so that the rows of the adherence table have the correct **start_time** and **end_time** (midnight to midnight in EDT)
<img width="781" alt="Screen Shot 2022-08-17 at 4 37 02 PM" src="https://user-images.githubusercontent.com/1455838/185261873-c8a08bcf-de1a-42af-81e6-45e3afaf4c9e.png">

Because of this, we need to change the logic of the adherence stream to be aware of timezones. Right now it ignores 8/16-8/17 (EDT) because the start time is the same calendar day (8/16) even though the data has already been generated.

