### PR TITLE
[BUG] resolve occasional key error in adherence stream

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="tap-assembled",
-    version="0.1.9",
+    version="0.1.10",
     description="Singer.io tap for extracting data from the Assembled API",
     author="Pathlight",
     url="http://pathlight.com",

--- a/tap_assembled/streams/adherence.py
+++ b/tap_assembled/streams/adherence.py
@@ -114,7 +114,7 @@ class AdherenceStream(BaseStream):
 		
 		if report:
 			total = report['total_metric_count']
-			count = len(report.get('metrics')) if report.get('metrics') else 0
+			count = len(report.get('metrics', []))
 			LOGGER.debug(f"tap-assembled: processing {total} metrics")
 			LOGGER.debug(f"tap-assembled: this batch had {count} metrics")	
 			while (total > (offset + count)):	

--- a/tap_assembled/streams/adherence.py
+++ b/tap_assembled/streams/adherence.py
@@ -114,7 +114,7 @@ class AdherenceStream(BaseStream):
 		
 		if report:
 			total = report['total_metric_count']
-			count = len(report['metrics'])
+			count = len(report.get('metrics')) if report.get('metrics') else 0
 			LOGGER.debug(f"tap-assembled: processing {total} metrics")
 			LOGGER.debug(f"tap-assembled: this batch had {count} metrics")	
 			while (total > (offset + count)):	


### PR DESCRIPTION
Occasionally running into a key error for the adherence stream. 

<img width="1519" alt="Screen Shot 2023-01-13 at 3 33 29 PM" src="https://user-images.githubusercontent.com/29642644/212437325-d6ab5350-6703-4600-8679-b70f963dbece.png">

Sometimes `report` does not include a `metrics` field. The fix here is to just use the `.get` for safe python dict access so that the entire tap doesn't just fail because of the key error.